### PR TITLE
proposed fix for #2

### DIFF
--- a/spotbot.py
+++ b/spotbot.py
@@ -106,6 +106,8 @@ class Spotbot(object):
         for p in posts:
             if any(x in p.lower() for x in ['spot-decision:', 'spot decision:', 'decision:']):
                 return p
+            elif p == posts[-1] and 'decision' in p.lower() and '?' not in p:
+                return p
         return None
 
     def create_thread(self, training):


### PR DESCRIPTION
This fix prevents all "what is the spot decision?" kind posts from slipping through by checking for a question mark, while also alleviating the danger of explanation posts like "the spot decision will be posted here around 1pm" by only checking the last posts for that branch